### PR TITLE
Handle descriptors defined in PyProxyBase subclasses like C

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 4.1.5 (unreleased)
 ------------------
 
-- TBD
+- The pure Python implementation handles descriptors defined in
+  subclasses like the C version. See
+  https://github.com/zopefoundation/zope.proxy/issues/5.
 
 4.1.4 (2014-03-19)
 ------------------

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -456,6 +456,11 @@ if 'PURE_PYTHON' not in os.environ:
     except ImportError: #pragma NO COVER
         pass
 
+class PyNonOverridable(object):
+    "Deprecated, only for BWC."
+    def __init__(self, method_desc): #pragma NO COVER PyPy
+        self.desc = method_desc
+
 if _c_available:
     # Python API:  not used in this module
     from zope.proxy._zope_proxy_proxy import ProxyBase

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -117,13 +117,17 @@ class PyProxyBase(object):
             # __class__ is special cased in the C implementation
             return wrapped.__class__
 
+        if name in ('__reduce__', '__reduce_ex__'):
+            # These things we specifically override and no one
+            # can stop us, not even a subclass
+            return object.__getattribute__(self, name)
+
         # First, look for descriptors in this object's type
         type_self = type(self)
         descriptor = _WrapperType_Lookup(type_self, name)
         if descriptor is _MARKER:
             # Nothing in the class, go straight to the wrapped object
             return getattr(wrapped, name)
-
 
         if hasattr(descriptor, '__get__'):
             if not hasattr(descriptor, '__set__'):
@@ -132,7 +136,7 @@ class PyProxyBase(object):
                 try:
                     return getattr(wrapped, name)
                 except AttributeError:
-                    raise
+                    pass
             # Data-descriptor on this type. Call it
             return descriptor.__get__(self, type_self)
         return descriptor

--- a/src/zope/proxy/tests/test_decorator.py
+++ b/src/zope/proxy/tests/test_decorator.py
@@ -135,6 +135,30 @@ class SpecificationDecoratorBaseTests(unittest.TestCase):
         proxy = self._makeOne(foo)
         self.assertEqual(list(providedBy(proxy)), list(providedBy(foo)))
 
+    def test_proxy_that_provides_interface_as_well_as_wrapped(self):
+        # If both the wrapper and the wrapped object provide
+        # interfaces, the wrapper provides the sum
+        from zope.interface import Interface
+        from zope.interface import implementer
+        from zope.interface import providedBy
+        class IFoo(Interface):
+            pass
+        @implementer(IFoo)
+        class Foo(object):
+            from_foo = 1
+
+        class IWrapper(Interface):
+            pass
+        @implementer(IWrapper)
+        class Proxy(self._getTargetClass()):
+            pass
+
+        foo = Foo()
+        proxy = Proxy(foo)
+
+        self.assertEqual(proxy.from_foo, 1)
+        self.assertEqual(list(providedBy(proxy)), [IFoo,IWrapper])
+
 
 def test_suite():
     return unittest.TestSuite((

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -650,7 +650,7 @@ class PyProxyBaseTestCase(unittest.TestCase):
         proxy = Proxy(object())
         # Both when called by the interpreter, which bypasses
         # __getattribute__
-        self.assertEquals(proxy[42], 42)
+        self.assertEqual(proxy[42], 42)
         # And when asked for as an attribute
         self.assertNotEqual(getattr(proxy, '__getitem__'), self)
 

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -642,6 +642,18 @@ class PyProxyBaseTestCase(unittest.TestCase):
         self.assertRaises(AttributeError, setattr, proxy, 'attr', 42)
         self.assertEqual(proxy.attr, "constant value")
 
+    def test_method_in_proxy_subclass(self):
+        class Proxy(self._getTargetClass()):
+            def __getitem__(self, k):
+                return k
+
+        proxy = Proxy(object())
+        # Both when called by the interpreter, which bypasses
+        # __getattribute__
+        self.assertEquals(proxy[42], 42)
+        # And when asked for as an attribute
+        self.assertNotEqual(getattr(proxy, '__getitem__'), self)
+
     def test_string_to_int(self):
         # XXX Implementation difference: This works in the
         # Pure-Python version, but fails in CPython.

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
 
 [testenv:coverage]
 basepython =
-    python2.6
+    python2.7
 commands = 
 #   The installed version messes up nose's test discovery / coverage reporting
 #   So, we uninstall that from the environment, and then install the editable


### PR DESCRIPTION
This fixes #5 plus a few other discrepancies I noticed during testing.

It also fixes the tox `py27-pure` environment, which wasn't actually exercising the pure Python code if the .so had already been built; now it takes an approach similar to other libraries and lets the environment variable take precedence.