### PR TITLE
Make Python proxy objects cooperate better with zope.interface/zope.component

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.1.6 (unreleased)
 ------------------
 
-- TBD
+- Made subclasses of ProxyBase properly delegate ``__module__`` to the
+  wrapped object.
 
 4.1.5 (2015-05-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changes
 ------------------
 
 - Made subclasses of ProxyBase properly delegate ``__module__`` to the
-  wrapped object.
+  wrapped object. This fixes some ``zope.interface`` lookups under
+  PyPy.
+- Made the pure-Python implementation of ProxyBase properly report the
+  ``zope.interface`` interfaces implemented by builtin types like
+  ``list``. This fixes some ``zope.interface`` lookups under PyPy.
 
 4.1.5 (2015-05-19)
 ------------------

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -131,9 +131,11 @@ class AbstractPyProxyBase(object):
         if name == '_wrapped':
             return _get_wrapped(self)
 
-        if name == '__class__':
-            # __class__ is special cased in the C implementation
-            return _get_wrapped(self).__class__
+        if name in ('__class__', '__module__'):
+            # __class__ and __module__ are special cased in the C
+            # implementation, because we will always find them on the
+            # type of this object if we are being subclassed
+            return getattr(_get_wrapped(self), name)
 
         if name in ('__reduce__', '__reduce_ex__'):
             # These things we specifically override and no one

--- a/src/zope/proxy/_zope_proxy_proxy.c
+++ b/src/zope/proxy/_zope_proxy_proxy.c
@@ -274,7 +274,9 @@ wrap_getattro(PyObject *self, PyObject *name)
 
     maybe_special_name = name_as_string[0] == '_' && name_as_string[1] == '_';
 
-    if (!(maybe_special_name && strcmp(name_as_string, "__class__") == 0)) {
+    if (!(maybe_special_name
+          && (strcmp(name_as_string, "__class__") == 0
+              || strcmp(name_as_string, "__module__") == 0))) {
 
         descriptor = WrapperType_Lookup(self->ob_type, name);
 


### PR DESCRIPTION
Also fix differences between the C and Python implementations in handling `__module__`, whether or not a subclass is involved.

This arises from the discussion in [zopetoolkit](https://github.com/zopefoundation/zopetoolkit/pull/2#issuecomment-106075153). When I looked into it, it turned out that in addition to not working properly for subclasses, there were also discrepancies in how the C and Python implementation handled it for non-subclass cases. The C implementation got it "right" for all except one case, but the Python implementation failed them all.

This obsoletes one of the changes in zopefoundation/zope.security#11 if we also version pin it to >= 4.1.6.