### PR TITLE
Fix removing pure python security proxies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
     - pypy
 install:
     - pip install .
+    - pip install zope.security
 script:
     - python setup.py test -q
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changes
 
 - Add support for Python 3.5.
 
+- Fixed failure when using removeAllProxies with zope.security proxies.
+
 4.1.6 (2015-06-02)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(name='zope.proxy',
       include_package_data = True,
       zip_safe = False,
       extras_require = {
-        'testing': ['nose', 'coverage'],
+        'testing': ['nose', 'coverage', 'zope.security'],
         'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
       },
 )

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -507,7 +507,7 @@ def py_queryInnerProxy(obj, klass=None, default=None):
 
 def py_removeAllProxies(obj):
     while isinstance(obj, PyProxyBase):
-        obj = obj._wrapped
+        obj = super(PyProxyBase, obj).__getattribute__('_wrapped')
     return obj
 
 _c_available = False

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -1276,6 +1276,11 @@ class Test_py_removeAllProxies(unittest.TestCase):
         from zope.proxy import PyProxyBase
         return PyProxyBase(obj)
 
+    def _makeSecurityProxy(self, obj):
+        from zope.security.proxy import ProxyPy
+        checker = object()
+        return ProxyPy(obj, checker)
+
     def test_no_proxy(self):
         class C(object):
             pass
@@ -1297,6 +1302,12 @@ class Test_py_removeAllProxies(unittest.TestCase):
         proxy2 = self._makeProxy(proxy)
         self.assertTrue(self._callFUT(proxy2) is c)
 
+    def test_security_proxy(self):
+        class C(object):
+            pass
+        c = C()
+        proxy = self._makeSecurityProxy(c)
+        self.assertTrue(self._callFUT(proxy) is c)
 
 class Test_removeAllProxies(unittest.TestCase):
 


### PR DESCRIPTION
The test is simple but requires zope.security to be installed.
I chose that over writing the test in zope.security