### PR TITLE
Fix tests w/o zope security

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,15 @@
 [buildout]
-parts = test
+parts =
+    test
+    test-wo-zope-security
 develop = .
 
 [test]
 recipe = zc.recipe.testrunner
-eggs = zope.proxy
+eggs =
+    zope.proxy[testing]
+
+[test-wo-zope-security]
+recipe = zc.recipe.testrunner
+eggs =
+    zope.proxy

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -15,6 +15,13 @@
 """
 import unittest
 
+try:
+    import zope.security
+except ImportError:
+    _HAVE_ZOPE_SECURITY = False
+else:
+    _HAVE_ZOPE_SECURITY = True
+
 
 class ModuleConformanceCase(unittest.TestCase):
 
@@ -1302,6 +1309,7 @@ class Test_py_removeAllProxies(unittest.TestCase):
         proxy2 = self._makeProxy(proxy)
         self.assertTrue(self._callFUT(proxy2) is c)
 
+    @unittest.skipUnless(_HAVE_ZOPE_SECURITY, 'zope.security missing')
     def test_security_proxy(self):
         class C(object):
             pass


### PR DESCRIPTION
Skip tests dependent on zope.security if it is missing.

Add a new testrunner, `test-wo-zope-security`, to exercise the `skipUnless` added in d910979.