### PR TITLE
Make py_sameProxiedObjects handle zope.security proxies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
     - 3.5
     - pypy
 install:
-    - pip install .
-    - pip install zope.security
+    - pip install -e .[test]
 script:
     - python setup.py test -q
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,14 @@ Changes
 4.2.1 (unreleased)
 ------------------
 
-- TBD
+- Make the pure-Python implementation of ``sameProxiedObjects`` handle
+  ``zope.security`` proxies. See `issue 15 <https://github.com/zopefoundation/zope.proxy/issues/15>`_.
 
 4.2.0 (2016-05-05)
 ------------------
 
 - Correctly strip ``zope.security`` proxies in ``removeAllProxies``.
+  See `issue 13 <https://github.com/zopefoundation/zope.proxy/pull/13>`_.
 
 - Avoid poisoning the user's global wheel cache when testing ``PURE_PYTHON``
   environments under ``tox``,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ import platform
 from setuptools import setup, Extension, Feature
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 Cwrapper = Feature(
     "C wrapper",
@@ -74,7 +75,8 @@ setup(name='zope.proxy',
           'Programming Language :: Python :: Implementation :: PyPy',
           "Framework :: Zope3",
           'Natural Language :: English',
-          'Operating System :: OS Independent'],
+          'Operating System :: OS Independent'
+      ],
       keywords='proxy generic transparent',
       packages=['zope', 'zope.proxy'],
       package_dir = {'': 'src'},
@@ -83,11 +85,13 @@ setup(name='zope.proxy',
       test_suite = 'zope.proxy',
       install_requires=[
           'zope.interface',
-          'setuptools'],
+          'setuptools',
+      ],
       include_package_data = True,
       zip_safe = False,
       extras_require = {
-        'testing': ['nose', 'coverage', 'zope.security'],
-        'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
+          'test': ['zope.security',],
+          'testing': ['nose', 'coverage', 'zope.security',],
+          'docs': ['Sphinx', 'repoze.sphinx.autointerface',],
       },
 )

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -479,9 +479,9 @@ def py_isProxy(obj, klass=None):
 
 def py_sameProxiedObjects(lhs, rhs):
     while isinstance(lhs, PyProxyBase):
-        lhs = lhs._wrapped
+        lhs = super(PyProxyBase, lhs).__getattribute__('_wrapped')
     while isinstance(rhs, PyProxyBase):
-        rhs = rhs._wrapped
+        rhs = super(PyProxyBase, rhs).__getattribute__('_wrapped')
     return lhs is rhs
 
 def py_queryProxy(obj, klass=None, default=None):

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -1050,6 +1050,12 @@ class Test_py_sameProxiedObjects(unittest.TestCase):
         from zope.proxy import PyProxyBase
         return PyProxyBase(obj)
 
+    def _makeSecurityProxy(self, obj):
+        from zope.security.proxy import ProxyPy
+        from zope.security.checker import CheckerPy
+        checker = CheckerPy({})
+        return ProxyPy(obj, checker)
+
     def test_bare_instance_identical(self):
         class C(object):
             pass
@@ -1112,6 +1118,20 @@ class Test_py_sameProxiedObjects(unittest.TestCase):
         self.assertFalse(self._callFUT(_mP(_mP(c1)), c2))
         self.assertFalse(self._callFUT(c2, _mP(_mP(c1))))
 
+    @unittest.skipUnless(_HAVE_ZOPE_SECURITY, 'zope.security missing')
+    def test_security_proxy(self):
+        class C(object):
+            pass
+        c1 = C()
+        proxy1 = self._makeSecurityProxy(c1)
+        proxy1_2 = self._makeSecurityProxy(c1)
+
+        self.assertTrue(self._callFUT(proxy1, proxy1))
+        self.assertTrue(self._callFUT(proxy1, proxy1_2))
+
+        c2 = C()
+        proxy2 = self._makeSecurityProxy(c2)
+        self.assertFalse(self._callFUT(proxy1, proxy2))
 
 class Test_sameProxiedObjects(Test_py_sameProxiedObjects):
 
@@ -1123,6 +1143,11 @@ class Test_sameProxiedObjects(Test_py_sameProxiedObjects):
         from zope.proxy import ProxyBase
         return ProxyBase(obj)
 
+    def _makeSecurityProxy(self, obj):
+        from zope.security.proxy import Proxy
+        from zope.security.checker import Checker
+        checker = Checker({})
+        return Proxy(obj, checker)
 
 class Test_py_queryProxy(unittest.TestCase):
 
@@ -1327,7 +1352,6 @@ class Test_removeAllProxies(unittest.TestCase):
         from zope.proxy import ProxyBase
         return ProxyBase(obj)
 
-
 class Test_ProxyIterator(unittest.TestCase):
 
     def _callFUT(self, *args):
@@ -1412,28 +1436,4 @@ class Comparable(object):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(ModuleConformanceCase),
-        unittest.makeSuite(PyProxyBaseTestCase),
-        unittest.makeSuite(ProxyBaseTestCase),
-        unittest.makeSuite(Test_py_getProxiedObject),
-        unittest.makeSuite(Test_getProxiedObject),
-        unittest.makeSuite(Test_py_setProxiedObject),
-        unittest.makeSuite(Test_setProxiedObject),
-        unittest.makeSuite(Test_py_isProxy),
-        unittest.makeSuite(Test_isProxy),
-        unittest.makeSuite(Test_py_sameProxiedObjects),
-        unittest.makeSuite(Test_sameProxiedObjects),
-        unittest.makeSuite(Test_py_queryProxy),
-        unittest.makeSuite(Test_queryProxy),
-        unittest.makeSuite(Test_py_queryInnerProxy),
-        unittest.makeSuite(Test_queryInnerProxy),
-        unittest.makeSuite(Test_py_removeAllProxies),
-        unittest.makeSuite(Test_removeAllProxies),
-        unittest.makeSuite(Test_ProxyIterator),
-        unittest.makeSuite(Test_nonOverridable),
-        unittest.makeSuite(Test_py__module),
-        unittest.makeSuite(Test__module),
-        unittest.makeSuite(Test_py_subclass__module),
-        unittest.makeSuite(Test_subclass__module),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
-envlist = 
+envlist =
 # Jython support pending 2.7 support, due 2012-07-15 or so.  See:
 # http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
 #   py27,jython,pypy,coverage
     py27,py27-pure,py33,py33-pure,py34,py35,pypy,coverage,docs
 
 [testenv]
-commands = 
+commands =
     python setup.py -q test -q
+deps =
+     .[test]
 
 [testenv:py27-pure]
 basepython =
@@ -24,13 +26,13 @@ setenv =
     PIP_CACHE_DIR = {envdir}/.cache
 
 [testenv:jython]
-commands = 
+commands =
    jython setup.py test -q
 
 [testenv:coverage]
 basepython =
     python2.7
-commands = 
+commands =
 #   The installed version messes up nose's test discovery / coverage reporting
 #   So, we uninstall that from the environment, and then install the editable
 #   version, before running nosetests.
@@ -38,14 +40,12 @@ commands =
     pip install -e .
     nosetests --with-xunit --with-xcoverage
 deps =
-    nose
-    coverage
-    nosexcover
+    .[testing]
 
 [testenv:docs]
 basepython =
     python2.7
-commands = 
+commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =


### PR DESCRIPTION
By effectively bypassing them to access `_wrapped`.

Fixes #15.

[There's still one more issue affecting zope.file, though, which may be another bug in this package or more likely zope.security:

```
 File "//zope.filepypy/site-packages/zope/app/container/browser/contents.py", line 94, in listContentInfo
        return self._normalListContentsInfo()
  File "//zope.filepypy/site-packages/zope/app/container/browser/contents.py", line 120, in _normalListContentsInfo
        info = map(self._extractContentInfo, self.context.items())
 File "//zope.filepypy/site-packages/zope/security/proxy.py", line 28, in _wrapper
        checker.check(wrapped, name)
 File "//zope.filepypy/site-packages/zope/security/checker.py", line 229, in check
        raise ForbiddenAttribute(name, object)
       - class: BTrees._base._TreeItems
       - type: BTrees._base._TreeItems
    ForbiddenAttribute: ('__iter__', <BTrees._base._TreeItems object at 0x0000000112a420c8>)
```
]