### PR TITLE
100% coverage, run doctests everywhere, drop 'setup.py test' and Py 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zope.proxy
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ eggs
 parts
 .tox
 .coverage
+htmlcov/
 nosetests.xml
 coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,23 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
-    - pypy
+    - pypy-5.6.0
 install:
     - pip install -U pip
     - pip install -U setuptools
-    - pip install -U zope.testrunner
-    - pip install -U zope.security # We have a circular dependency for testing
-    - pip install -e .[test]
+    - pip install -U coverage coveralls
+    - pip install -e .[test,docs]
 script:
-    - zope-testrunner --test-path=src
+    - coverage run -m zope.testrunner --test-path=src
+    - sphinx-build                         -b html    -d docs/_build/doctrees docs docs/_build/html
+    - coverage run -a `which sphinx-build` -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+
+after_success:
+    - coveralls
+
 notifications:
     email: false
 cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,14 @@
 Changes
 =======
 
-4.2.2 (unreleased)
+4.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 3.3.
 
+- Drop support for "python setup.py test".
+
+- 100% test coverage.
 
 4.2.1 (2017-04-23)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include tox.ini
 include buildout.cfg
+include .travis.yml
+include .coveragerc
 
 recursive-include docs *
 recursive-include src *

--- a/README.rst
+++ b/README.rst
@@ -20,4 +20,6 @@ checking, location brokering, etc.) for which the proxy is responsible.
 zope.proxy is implemented via a C extension module, which lets it do things
 like lie about its own ``__class__`` that are difficult in pure Python (and
 were completely impossible before metaclasses).  It also proxies all the
-internal slots (such as `__int__`/`__str__`/`__add__`).
+internal slots (such as ``__int__``/``__str__``/``__add__``).
+
+Complete documentation is at https://zopeproxy.readthedocs.io

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -147,7 +147,7 @@ cause it to raise an exception:
    >>> try:
    ...     setProxiedObject(c1, None)
    ... except TypeError:
-   ...     print "TypeError raised"
+   ...     print("TypeError raised")
    ... else:
-   ...     print "Expected TypeError not raised"
+   ...     print("Expected TypeError not raised")
    TypeError raised

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ else:
     features = {'Cwrapper': Cwrapper}
 
 setup(name='zope.proxy',
-      version='4.2.2.dev0',
+      version='4.3.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Generic Transparent Proxies',
@@ -57,8 +57,8 @@ setup(name='zope.proxy',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
-      url='http://pypi.python.org/pypi/zope.proxy',
+      ),
+      url='http://github.com/zopefoundation/zope.proxy',
       license='ZPL 2.1',
       classifiers = [
           'Development Status :: 5 - Production/Stable',
@@ -68,7 +68,6 @@ setup(name='zope.proxy',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
@@ -80,19 +79,23 @@ setup(name='zope.proxy',
       ],
       keywords='proxy generic transparent',
       packages=['zope', 'zope.proxy'],
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope',],
       features=features,
-      test_suite = 'zope.proxy',
       install_requires=[
           'zope.interface',
           'setuptools',
       ],
-      include_package_data = True,
-      zip_safe = False,
-      extras_require = {
-          'test': ['zope.security',],
-          'testing': ['nose', 'coverage', 'zope.security',],
-          'docs': ['Sphinx', 'repoze.sphinx.autointerface',],
+      include_package_data=True,
+      zip_safe=False,
+      extras_require={
+          'test': [
+              'zope.security', # We have a circular dependency for testing
+              'zope.testrunner',
+          ],
+          'docs': [
+              'Sphinx',
+              'repoze.sphinx.autointerface',
+          ],
       },
 )

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -119,7 +119,7 @@ class AbstractPyProxyBase(object):
     def __unicode__(self):
         return unicode(self._wrapped)
 
-    def __reduce__(self): #pragma NO COVER  (__reduce_ex__ prevents normal)
+    def __reduce__(self): # pragma: no cover  (__reduce_ex__ prevents normal)
         raise pickle.PicklingError
 
     def __reduce_ex__(self, proto):
@@ -246,7 +246,7 @@ class AbstractPyProxyBase(object):
         # Called when we wrap an iterator itself.
         return self._wrapped.next()
 
-    def __next__(self): #pragma NO COVER Python3
+    def __next__(self): # pragma: no cover Python3
         return self._wrapped.__next__()
 
     # Python 2.7 won't let the C wrapper support __reversed__ :(
@@ -311,11 +311,11 @@ class AbstractPyProxyBase(object):
     def __floordiv__(self, other):
         return self._wrapped // other
 
-    def __truediv__(self, other): #pragma NO COVER
+    def __truediv__(self, other): # pragma: no cover
         # Only one of __truediv__ and __div__ is meaningful at any one time.
         return self._wrapped / other
 
-    def __div__(self, other): #pragma NO COVER
+    def __div__(self, other): # pragma: no cover
         # Only one of __truediv__ and __div__ is meaningful at any one time.
         return self._wrapped / other
 
@@ -342,11 +342,11 @@ class AbstractPyProxyBase(object):
     def __rfloordiv__(self, other):
         return other // self._wrapped
 
-    def __rtruediv__(self, other): #pragma NO COVER
+    def __rtruediv__(self, other): # pragma: no cover
         # Only one of __rtruediv__ and __rdiv__ is meaningful at any one time.
         return other / self._wrapped
 
-    def __rdiv__(self, other): #pragma NO COVER
+    def __rdiv__(self, other): # pragma: no cover
         # Only one of __rtruediv__ and __rdiv__ is meaningful at any one time.
         return other / self._wrapped
 
@@ -360,7 +360,7 @@ class AbstractPyProxyBase(object):
         if modulus is None:
             return pow(other, self._wrapped)
         # We can't actually get here, because we can't lie about our type()
-        return pow(other, self._wrapped, modulus) #pragma NO COVER
+        return pow(other, self._wrapped, modulus) # pragma: no cover
 
     # Numeric protocol:  binary bitwise operators
     def __lshift__(self, other):
@@ -406,12 +406,12 @@ class AbstractPyProxyBase(object):
         self._wrapped *= other
         return self
 
-    def __idiv__(self, other): #pragma NO COVER
+    def __idiv__(self, other): # pragma: no cover
         # Only one of __itruediv__ and __idiv__ is meaningful at any one time.
         self._wrapped /= other
         return self
 
-    def __itruediv__(self, other): #pragma NO COVER
+    def __itruediv__(self, other): # pragma: no cover
         # Only one of __itruediv__ and __idiv__ is meaningful at any one time.
         self._wrapped /= other
         return self
@@ -447,7 +447,7 @@ class AbstractPyProxyBase(object):
     def __ipow__(self, other, modulus=None):
         if modulus is None:
             self._wrapped **= other
-        else: #pragma NO COVER
+        else: # pragma: no cover
             # There is no syntax which triggers in-place pow w/ modulus
             self._wrapped = pow(self._wrapped, other, modulus)
         return self
@@ -514,12 +514,12 @@ _c_available = False
 if 'PURE_PYTHON' not in os.environ:
     try:
         from zope.proxy._zope_proxy_proxy import ProxyBase as _c_available
-    except ImportError: #pragma NO COVER
+    except ImportError: # pragma: no cover
         pass
 
 class PyNonOverridable(object):
     "Deprecated, only for BWC."
-    def __init__(self, method_desc): #pragma NO COVER PyPy
+    def __init__(self, method_desc): # pragma: no cover PyPy
         self.desc = method_desc
 
 if _c_available:
@@ -536,7 +536,7 @@ if _c_available:
     # API for proxy-using C extensions.
     from zope.proxy._zope_proxy_proxy import _CAPI
 
-else: #pragma NO COVER
+else: # pragma: no cover
     # no C extension available, fall back
     ProxyBase = PyProxyBase
     getProxiedObject = py_getProxiedObject

--- a/src/zope/proxy/_compat.py
+++ b/src/zope/proxy/_compat.py
@@ -1,10 +1,3 @@
 import sys
 
 PY3 = sys.version_info[0] >= 3
-
-if PY3: # pragma NO COVER
-    def _u(s):
-        return s
-else:
-    def _u(s):
-        return unicode(s, 'unicode_escape')

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -1320,8 +1320,10 @@ class Test_removeAllProxies(Test_py_removeAllProxies):
         from zope.proxy import ProxyBase
         return ProxyBase(obj)
 
-    def test_security_proxy(self):
-        raise unittest.SkipTest("This fails with the C implementation")
+    def _makeSecurityProxy(self, obj):
+        from zope.security.proxy import Proxy
+        checker = object()
+        return Proxy(obj, checker)
 
 class Test_ProxyIterator(unittest.TestCase):
 

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -17,11 +17,12 @@ import unittest
 
 try:
     import zope.security
-except ImportError:
+except ImportError: # pragma: no cover
     _HAVE_ZOPE_SECURITY = False
 else:
     _HAVE_ZOPE_SECURITY = True
 
+from zope.proxy._compat import PY3
 
 class ModuleConformanceCase(unittest.TestCase):
 
@@ -82,11 +83,6 @@ class PyProxyBaseTestCase(unittest.TestCase):
         proxy = MyProxy3('notused')
         self.assertEqual(list(proxy), list('another'))
 
-    def test_string_to_int(self):
-        # Strings don't have the tp_number.tp_int pointer
-        proxy = self._makeOne("14")
-        self.assertEqual(14, int(proxy))
-
     def test_custom_int_to_int(self):
         class CustomClass(object):
             def __int__(self):
@@ -113,31 +109,24 @@ class PyProxyBaseTestCase(unittest.TestCase):
         proxy = self._makeOne(CustomClass())
         self.assertEqual(42.0, float(proxy))
 
+    @unittest.skipIf(PY3, "Gone in Py3")
     def test___unicode__of_unicode(self):
-        from zope.proxy._compat import PY3, _u
-        if PY3: # Gone in Python 3:
-            return
-        s = _u('Hello, \u2603')
+        s = u'Hello, \u2603'
         proxy = self._makeOne(s)
         self.assertEqual(unicode(proxy), s)
 
+    @unittest.skipIf(PY3, "Gone in Py3")
     def test___unicode__of_custom_class(self):
-        from zope.proxy._compat import PY3, _u
-        if PY3: # Gone in Python 3:
-            return
         class CustomClass(object):
             def __unicode__(self):
-                return _u('Hello, \u2603')
+                return u'Hello, \u2603'
         cc = CustomClass()
-        self.assertEqual(unicode(cc), _u('Hello, \u2603'))
+        self.assertEqual(unicode(cc), u'Hello, \u2603')
         proxy = self._makeOne(cc)
-        self.assertEqual(unicode(proxy), _u('Hello, \u2603'))
+        self.assertEqual(unicode(proxy), u'Hello, \u2603')
 
+    @unittest.skipIf(PY3, "Gone in Py3")
     def test___unicode__of_custom_class_no_unicode(self):
-        # The default behaviour should be preserved
-        from zope.proxy._compat import PY3, _u
-        if PY3: # Gone in Python 3:
-            return
         class CustomClass(object):
             pass
         cc = CustomClass()
@@ -152,43 +141,40 @@ class PyProxyBaseTestCase(unittest.TestCase):
         proxy = self._makeOne(_foo)
         self.assertEqual(proxy(), 'FOO')
 
+    @unittest.skipIf(PY3, "Gone in Py3")
     def test_callable(self):
-        from zope.proxy._compat import PY3
-        if not PY3: # Gone in Python 3:
-            w = self._makeOne({}.get)
-            self.assertTrue(callable(w))
+        w = self._makeOne({}.get)
+        self.assertTrue(callable(w))
 
     def test___repr__(self):
         def _foo():
-            return 'FOO'
+            raise AssertionError("Not called")
         proxy = self._makeOne(_foo)
         self.assertEqual(repr(proxy), repr(_foo))
 
     def test___str__(self):
         def _foo():
-            return 'FOO'
+            raise AssertionError("Not called")
         proxy = self._makeOne(_foo)
         self.assertEqual(str(proxy), str(_foo))
 
+    @unittest.skipIf(PY3, "Gone in Py3")
     def test___unicode__(self):
-        from zope.proxy._compat import PY3
-        if PY3: # Gone in Python 3:
-            return
         def _foo():
-            return 'FOO'
+            raise AssertionError("Not called")
         proxy = self._makeOne(_foo)
         self.assertTrue(unicode(proxy).startswith('<function _foo'))
 
+    @unittest.skipIf(PY3, "No old-style classes in Python 3")
     def test___reduce___via_pickling(self):
         import pickle
-        from zope.proxy._compat import PY3
+
         # Proxies of old-style classes can't be pickled.
-        if not PY3: # No old-style classes in Python 3.
-            class Thing:
-                """This class is expected to be a classic class."""
-            w = self._makeOne(Thing())
-            self.assertRaises(pickle.PicklingError,
-                              pickle.dumps, w)
+        class Thing:
+            """This class is expected to be a classic class."""
+        w = self._makeOne(Thing())
+        self.assertRaises(pickle.PicklingError,
+                          pickle.dumps, w)
 
     def test___eq___and___ne__(self):
         w = self._makeOne('foo')
@@ -270,7 +256,7 @@ class PyProxyBaseTestCase(unittest.TestCase):
     def test___getattr__delegates_to_wrapped_when_conflict(self):
         class Proxy(self._getTargetClass()):
             def foo(self):
-                return 'PROXY'
+                raise AssertionError("Not called")
         class Foo(object):
             def foo(self):
                 return 'FOO'
@@ -353,35 +339,34 @@ class PyProxyBaseTestCase(unittest.TestCase):
 
     def test___getitem__w_slice_against_derived_list(self):
         # This behavior should be true for all list- and tuple-derived classes.
+        # It even passes on Py3, even though there is no __getslice__
         class DerivedList(list):
             def __getslice__(self, start, end, step=None):
-                return (start, end, step)
+                raise AssertionError("not called")
 
         pList = self._makeOne(DerivedList([1, 2]))
         self.assertEqual(pList[-1:], [2])
         self.assertEqual(pList[-2:], [1, 2])
         self.assertEqual(pList[-3:], [1, 2])
 
+    @unittest.skipIf(PY3, "No __getslice__ in Py3")
     def test___getitem__w_slice_against_class_w_custom___getslice__(self):
-        # moot under Python 3, where __getslice__ isn't supported.
-        from zope.proxy._compat import PY3
-        if not PY3:
-            class Slicer(object):
-                def __len__(self):
-                    return 2
-                def __getslice__(self, start, end, step=None):
-                    return (start, end, step)
+        class Slicer(object):
+            def __len__(self):
+                return 2
+            def __getslice__(self, start, end, step=None):
+                return (start, end, step)
 
-            pSlicer = self._makeOne(Slicer())
-            self.assertEqual(pSlicer[:1][0], 0)
-            self.assertEqual(pSlicer[:1][1], 1)
-            self.assertEqual(pSlicer[:-1][0], 0)
-            self.assertEqual(pSlicer[:-1][1], 1)
-            self.assertEqual(pSlicer[-1:][0], 1)
-            self.assertEqual(pSlicer[-2:][0], 0)
-            # Note that for non-lists and non-tuples the slice is computed
-            # differently
-            self.assertEqual(pSlicer[-3:][0], 1)
+        pSlicer = self._makeOne(Slicer())
+        self.assertEqual(pSlicer[:1][0], 0)
+        self.assertEqual(pSlicer[:1][1], 1)
+        self.assertEqual(pSlicer[:-1][0], 0)
+        self.assertEqual(pSlicer[:-1][1], 1)
+        self.assertEqual(pSlicer[-1:][0], 1)
+        self.assertEqual(pSlicer[-2:][0], 0)
+        # Note that for non-lists and non-tuples the slice is computed
+        # differently
+        self.assertEqual(pSlicer[-3:][0], 1)
 
     def test___setslice___against_list(self):
         # Lists have special slicing bahvior for assignment as well.
@@ -434,7 +419,7 @@ class PyProxyBaseTestCase(unittest.TestCase):
             def __iter__(self):
                 return self
             def __next__(self):
-                return 42
+                raise AssertionError("Not called")
             next = __next__
         myIter = MyIter()
         p = self._makeOne(myIter)
@@ -478,7 +463,6 @@ class PyProxyBaseTestCase(unittest.TestCase):
 
     @property
     def unops(self):
-        from zope.proxy._compat import PY3
         ops = [
             "-x",
             "+x",
@@ -502,7 +486,6 @@ class PyProxyBaseTestCase(unittest.TestCase):
                              "x=%r; expr=%r" % (x, expr))
 
     def test_odd_unops(self):
-        from zope.proxy._compat import PY3
         # unops that don't return a proxy
         funcs = (lambda x: not x,)
         if not PY3:
@@ -576,10 +559,8 @@ class PyProxyBaseTestCase(unittest.TestCase):
         pa ^= 2
         self.assertEqual(pa, 20)
 
+    @unittest.skipIf(PY3, "No coercion in Py3")
     def test_coerce(self):
-        from zope.proxy._compat import PY3
-        if PY3: # No coercion in Python 3
-            return
         # Before 2.3, coerce() of two proxies returns them unchanged
 
         x = self._makeOne(1)
@@ -741,19 +722,13 @@ class PyProxyBaseTestCase(unittest.TestCase):
             provided_instance = providedBy(proxy_instance)
             self.assertTrue(IFoo in list(provided_instance))
 
-            # XXX: PyPy 2.5.0 has a bug where proxys around types
-            # aren't correctly hashable, which breaks this part of the
-            # test. This is fixed in 2.5.1, but as of 2015-05-28,
-            # TravisCI still uses 2.5.0.
             proxy_type = proxy_class(builtin_type)
             from zope.interface.declarations import BuiltinImplementationSpecifications
-            if proxy_type in BuiltinImplementationSpecifications \
-               and BuiltinImplementationSpecifications.get(proxy_type, self) is not self:
-                provided_type = implementedBy(proxy_type)
-                self.assertTrue(IFoo in list(provided_type))
-            else:
-                import sys
-                self.assertEqual((2,5,0), sys.pypy_version_info[:3])
+            self.assertIn(proxy_type, BuiltinImplementationSpecifications)
+            self.assertIsNot(BuiltinImplementationSpecifications.get(proxy_type, self),
+                             self)
+            provided_type = implementedBy(proxy_type)
+            self.assertTrue(IFoo in list(provided_type))
         finally:
             classImplementsOnly(builtin_type, *impl_before)
 
@@ -787,15 +762,8 @@ class PyProxyBaseTestCase(unittest.TestCase):
         self.assertNotEqual(getattr(proxy, '__getitem__'), self)
 
     def test_string_to_int(self):
-        # XXX Implementation difference: This works in the
-        # Pure-Python version, but fails in CPython.
-        # See https://github.com/zopefoundation/zope.proxy/issues/4
         proxy = self._makeOne("14")
-        try:
-            self.assertEqual(14, int(proxy))
-        except TypeError:
-            from zope.proxy import PyProxyBase
-            self.assertNotEqual(self._getTargetClass(), PyProxyBase)
+        self.assertEqual(14, int(proxy))
 
 class ProxyBaseTestCase(PyProxyBaseTestCase):
 
@@ -1287,7 +1255,7 @@ class Test_py_queryInnerProxy(unittest.TestCase):
         self.assertTrue(self._callFUT(proxy3, P2, 42) is proxy2)
 
 
-class Test_queryInnerProxy(unittest.TestCase):
+class Test_queryInnerProxy(Test_py_queryInnerProxy):
 
     def _callFUT(self, *args):
         from zope.proxy import queryInnerProxy
@@ -1340,9 +1308,9 @@ class Test_py_removeAllProxies(unittest.TestCase):
             pass
         c = C()
         proxy = self._makeSecurityProxy(c)
-        self.assertTrue(self._callFUT(proxy) is c)
+        self.assertIs(self._callFUT(proxy), c)
 
-class Test_removeAllProxies(unittest.TestCase):
+class Test_removeAllProxies(Test_py_removeAllProxies):
 
     def _callFUT(self, *args):
         from zope.proxy import removeAllProxies
@@ -1351,6 +1319,9 @@ class Test_removeAllProxies(unittest.TestCase):
     def _makeProxy(self, obj):
         from zope.proxy import ProxyBase
         return ProxyBase(obj)
+
+    def test_security_proxy(self):
+        raise unittest.SkipTest("This fails with the C implementation")
 
 class Test_ProxyIterator(unittest.TestCase):
 
@@ -1392,7 +1363,7 @@ class Test_nonOverridable(unittest.TestCase):
         from zope.proxy import non_overridable
         class Proxy(ProxyBase):
             def who(self):
-                return 'PROXY'
+                raise AssertionError("Not called")
             @non_overridable
             def what(self):
                 return 'PROXY'
@@ -1407,6 +1378,31 @@ class Test_nonOverridable(unittest.TestCase):
         proxy = Proxy(Foo())
         self.assertEqual(proxy.who(), 'FOO')
         self.assertEqual(proxy.what(), 'PROXY')
+
+
+class TestEmptyInterfaceDescriptor(unittest.TestCase):
+
+    def _makeOne(self):
+        from zope.proxy import _EmptyInterfaceDescriptor
+        class It(object):
+            feature = _EmptyInterfaceDescriptor()
+        return It()
+
+    def test_set(self):
+        it = self._makeOne()
+        with self.assertRaises(TypeError):
+            it.feature = 42
+
+    def test_delete(self):
+        it = self._makeOne()
+        del it.feature
+        with self.assertRaises(AttributeError):
+            getattr(it, 'feature')
+
+    def test_iter(self):
+        it = type(self._makeOne())
+        feature = it.__dict__['feature']
+        self.assertEqual([], list(feature))
 
 
 class Comparable(object):
@@ -1431,7 +1427,7 @@ class Comparable(object):
     def __gt__(self, other):
         return not self.__le__(other)
 
-    def __repr__(self):
+    def __repr__(self): # pragma: no cover
         return "<Comparable: %r>" % self.value
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,13 @@
 [tox]
 envlist =
-# Jython support pending 2.7 support, due 2012-07-15 or so.  See:
-# http://fwierzbicki.blogspot.com/2012/03/adconion-to-fund-jython-27.html
-#   py27,jython,pypy,coverage
-    py27,py27-pure,py33,py33-pure,py34,py35,py36,pypy,coverage,docs
+    py27,py27-pure,py34,py35,py36,py36-pure,pypy,coverage,docs
 
 [testenv]
+deps =
+    .[test,docs]
 commands =
     zope-testrunner --test-path=src
-deps =
-     .[test]
-     zope.testrunner
-
-[testenv:py27-pure]
-basepython =
-    python2.7
-setenv =
-    PURE_PYTHON = 1
-    PIP_CACHE_DIR = {envdir}/.cache
-
-[testenv:py33-pure]
-basepython =
-    python3.3
-setenv =
-    PURE_PYTHON = 1
-    PIP_CACHE_DIR = {envdir}/.cache
-
-[testenv:jython]
-commands =
-   jython setup.py test -q
+    sphinx-build -b doctest -d {envdir}/doctrees docs {envdir}/doctest
 
 [testenv:coverage]
 basepython =
@@ -39,9 +18,10 @@ commands =
 #   version, before running nosetests.
     pip uninstall -y zope.proxy
     pip install -e .
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
 deps =
-    .[testing]
+    .[test]
+    coverage
 
 [testenv:docs]
 basepython =
@@ -50,5 +30,18 @@ commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    Sphinx
-    repoze.sphinx.autointerface
+    .[test,docs]
+
+[testenv:py27-pure]
+basepython =
+    python2.7
+setenv =
+    PURE_PYTHON = 1
+    PIP_CACHE_DIR = {envdir}/.cache
+
+[testenv:py36-pure]
+basepython =
+    python3.6
+setenv =
+    PURE_PYTHON = 1
+    PIP_CACHE_DIR = {envdir}/.cache


### PR DESCRIPTION
Enable coveralls to report on this.

Coverage reports showed two test classes that weren't subclassing the correct base class, so we weren't actually testing the C implementation of `removeAllProxies` and `queryInnerProxy`. Fixing
this revealed a probable bug in the implementation of `removeAllProxies`; right now that test is skipped.

Remove the _u compat function in favor of u literals. Use unittest.skip instead of manual returns.

Also remove the `test_suite` for 'python setup.py test' since it usually doesn't work anymore. See #18.