### PR TITLE
Fix indexing pure-Python proxies on Py3, and restore __getslice__ on Py2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ Changes
 
 - 100% test coverage.
 
+- Fix indexing pure-Python proxies with slices under Python 3, and
+  restore the use of ``__getslice__`` (if implemented by the target's
+  type) under Python 2. Previously, pure-Python proxies would fail
+  with an AttributeError when given a slice on Python 3, and on Python
+  2, a custom ``__getslice__`` was ignored. See `issue 21
+  <https://github.com/zopefoundation/zope.proxy/issues/21>`_.
+
 4.2.1 (2017-04-23)
 ------------------
 

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -216,21 +216,22 @@ class AbstractPyProxyBase(object):
     def __len__(self):
         return len(self._wrapped)
 
+    def __getslice__(self, start, stop):
+        try:
+            getslice = type(self._wrapped).__getslice__
+        except AttributeError:
+            return self.__getitem__(slice(start, stop))
+        return getslice(self._wrapped, start, stop)
+
     def __getitem__(self, key):
-        if isinstance(key, slice):
-            if isinstance(self._wrapped, (list, tuple)):
-                return self._wrapped[key]
-            start, stop = key.start, key.stop
-            if start is None:
-                start = 0
-            if start < 0:
-                start += len(self._wrapped)
-            if stop is None:
-                stop = sys.maxint
-            if stop < 0:
-                stop += len(self._wrapped)
-            return operator.getslice(self._wrapped, start, stop)
         return self._wrapped[key]
+
+    def __setslice__(self, start, stop, value):
+        try:
+            setslice = type(self._wrapped).__setslice__
+        except AttributeError:
+            return self.__setitem__(slice(start, stop), value)
+        return setslice(self._wrapped, start, stop, value)
 
     def __setitem__(self, key, value):
         self._wrapped[key] = value

--- a/tox.ini
+++ b/tox.ini
@@ -10,17 +10,15 @@ commands =
     sphinx-build -b doctest -d {envdir}/doctrees docs {envdir}/doctest
 
 [testenv:coverage]
+usedevelop = true
 basepython =
     python2.7
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y zope.proxy
-    pip install -e .
-    coverage run -m zope.testrunner --test-path=src
+    coverage run -m zope.testrunner --test-path=src []
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report --fail-under=100
 deps =
-    .[test]
+    {[testenv]deps}
     coverage
 
 [testenv:docs]


### PR DESCRIPTION
Fixes #21.

This removes the special cases for lists and tuples in the C code (but requires an #if Python 2 block). Tests are added (and generalized for Python 3). I verified that this fixes the issues observed in the
zope.security tests.