### PR TITLE
Simplify getting the char* in get/setattro for clarity and performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Simplify the internal C handling of attribute names in
+  ``__getattribute__`` and ``__setattr__``.
 
 
 4.3.0 (2017-09-13)


### PR DESCRIPTION
Under Python 2, we were doing
PyUnicode_check->PyUnicode_AsEncodedString->PyString_Check->PyString_ASSTRING.

This can be simplified to PyString_AsString(). Internally it does the same unicode check if needed. It produces a better error message if the object is not a string or unicode. It is able to use the *cached* byte string, and it doesn't allocate a new object. Because we don't allocate a new object (sometimes) anymore, the extra INCREF/DECREF can go away. We're also able to drop one type check.

Under Python 3, we were doing PyUnicode_Check->PyUnicode_AsUTF8String ->PyBytes_AS_STRING. This can be simified to PyUnicode_AsUTF8. This avoids an intermediate object and can use the cached byte string. We can also drop the extra INCREF/DECREF since we don't ever have a new object.

Python 2 docs claimed that the underlying tp_getattro slots need a string object, but the unicode->string handling is done internally in Python's PyObject_GetAttr now, AFAICS. (It's difficult to get a
unicode object in to these methods in the first place; someone must be explicitly calling the __getattribute__ dunder method.)