### PR TITLE
Drop Python 3.3 from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
   matrix:
     - python: 27
     - python: 27-x64
-    - python: 33
-    - python: 33-x64
     - python: 34
     - python: 34-x64
     - python: 35


### PR DESCRIPTION
Support for 3.3 was dropped in version 4.3.0.