### PR TITLE
Fix error handling in the tp_setattro slot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 4.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error handling in ``ProxyBase.__setattr__``: any the exception raised by
+  ``PyString_AsString``/``PyUnicode_AsUTF8`` would be silently swallowed up
+  and ignored.  See `issue 31
+  <https://github.com/zopefoundation/zope.proxy/issues/31>`_.
 
 
 4.3.1 (2018-08-09)

--- a/src/zope/proxy/_zope_proxy_proxy.c
+++ b/src/zope/proxy/_zope_proxy_proxy.c
@@ -312,7 +312,7 @@ wrap_setattro(PyObject *self, PyObject *name, PyObject *value)
 #endif
 
     if (name_as_string == NULL) {
-        return NULL;
+        goto finally;
     }
 
     descriptor = WrapperType_Lookup(self->ob_type, name);


### PR DESCRIPTION
The docs say this callback is supposed to return -1 on error.

Fixes #30.