### PR TITLE
Downgrading sphinx to provide support for repoze.sphinx.autointerface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setup(name='zope.proxy',
               'zope.testrunner',
           ],
           'docs': [
-              'Sphinx',
+              'Sphinx<4', # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it
               'repoze.sphinx.autointerface',
           ],
       },


### PR DESCRIPTION
Downgraded the sphinx version to be less than 4 in setup.py, as missing dependencies need to be added in Sphinx 4.0 
Refer to this open [issue](https://github.com/repoze/repoze.sphinx.autointerface/issues/16).

Testing log: [Test_logs_arm64.success.txt](https://github.com/zopefoundation/zope.proxy/files/6707920/Test_logs_arm64.success.txt.txt)
