### PR TITLE
Update to the latest c-code template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -141,18 +142,36 @@ jobs:
 
       - name: Install Build Dependencies (PyPy2)
         if: >
-           startsWith(matrix.python-version, 'pypy-2.7')
+          startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
       - name: Install Build Dependencies (other Python versions)
         if: >
-           !startsWith(matrix.python-version, 'pypy-2.7')
+          !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build zope.proxy
+      - name: Build zope.proxy (Python 3.10 on MacOS)
+        if: >
+          startsWith(runner.os, 'Mac')
+          && startsWith(matrix.python-version, '3.10')
+        env:
+          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install .[test]
+
+      - name: Build zope.proxy (all other versions)
+        if: >
+          !startsWith(runner.os, 'Mac')
+          || !startsWith(matrix.python-version, '3.10')
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -26,6 +26,19 @@ ls -ld /cache/pip
 # We need some libraries because we build wheels from scratch:
 yum -y install libffi-devel
 
+tox_env_map() {
+    case $1 in
+        *"cp27"*) echo 'py27';;
+        *"cp35"*) echo 'py35';;
+        *"cp36"*) echo 'py36';;
+        *"cp37"*) echo 'py37';;
+        *"cp38"*) echo 'py38';;
+        *"cp39"*) echo 'py39';;
+        *"cp310"*) echo 'py310';;
+        *) echo 'py';;
+    esac
+}
+
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
@@ -40,8 +53,9 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
-          "${PYBIN}/pip" install tox
-          "${PYBIN}/tox" -e py
+          ${PYBIN}/pip install tox
+          TOXENV=$(tox_env_map "${PYBIN}")
+          ${PYBIN}/tox -e ${TOXENV}
           cd ..
         fi
         rm -rf /io/build /io/*.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "cde9741a5a0d9d04cee25cb617ee1590afebb17d"
+commit-id = "5c53fd90b1a529f2d1d4ed361d3bfa646520ba58"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Disable unsafe math optimizations in C code.  See `pull request 53
+  <https://github.com/zopefoundation/zope.proxy/pull/53>`_.
 
 
 4.5.0 (2021-11-17)

--- a/src/zope/proxy/tests/test_compile_flags.py
+++ b/src/zope/proxy/tests/test_compile_flags.py
@@ -1,0 +1,29 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+import struct
+import unittest
+
+import zope.proxy  # noqa: try to load a C module for side effects
+
+
+class TestFloatingPoint(unittest.TestCase):
+
+    def test_no_fast_math_optimization(self):
+        # Building with -Ofast enables -ffast-math, which sets certain FPU
+        # flags that can cause breakage elsewhere.  A library such as BTrees
+        # has no business changing global FPU flags for the entire process.
+        zero_bits = struct.unpack("!Q", struct.pack("!d", 0.0))[0]
+        next_up = zero_bits + 1
+        smallest_subnormal = struct.unpack("!d", struct.pack("!Q", next_up))[0]
+        self.assertNotEqual(smallest_subnormal, 0.0)


### PR DESCRIPTION
Add a regression test for CFLAGS not having -Ofast, which is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.