### PR TITLE
Remove proxying code for names that no longer exist in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 
 - Drop support for Python 2.7, 3.5, 3.6.
 
+- Remove proxying code for names that no longer exist in Python 3
+  like ``__long__`` and some others.
+  (`#55 <https://github.com/zopefoundation/zope.proxy/issues/55>`_)
+
 
 4.6.1 (2022-11-16)
 ==================

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -148,9 +148,8 @@ class AbstractPyProxyBase:
     def __ge__(self, other):
         return self._wrapped >= other
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self._wrapped)
-    __bool__ = __nonzero__  # Python3 compat
 
     def __hash__(self):
         return hash(self._wrapped)
@@ -283,19 +282,8 @@ class AbstractPyProxyBase:
     def __int__(self):
         return int(self._wrapped)
 
-    # BBB Should go away after zope.security is fixed
-    # see https://github.com/zopefoundation/zope.security/issues/92
-    def __long__(self):
-        return long(self._wrapped)  # noqa: F821 undefined name
-
     def __float__(self):
         return float(self._wrapped)
-
-    def __oct__(self):
-        return oct(self._wrapped)
-
-    def __hex__(self):
-        return hex(self._wrapped)
 
     def __index__(self):
         return operator.index(self._wrapped)
@@ -314,11 +302,6 @@ class AbstractPyProxyBase:
         return self._wrapped // other
 
     def __truediv__(self, other):  # pragma: no cover
-        # Only one of __truediv__ and __div__ is meaningful at any one time.
-        return self._wrapped / other
-
-    def __div__(self, other):  # pragma: no cover
-        # Only one of __truediv__ and __div__ is meaningful at any one time.
         return self._wrapped / other
 
     def __mod__(self, other):
@@ -345,11 +328,6 @@ class AbstractPyProxyBase:
         return other // self._wrapped
 
     def __rtruediv__(self, other):  # pragma: no cover
-        # Only one of __rtruediv__ and __rdiv__ is meaningful at any one time.
-        return other / self._wrapped
-
-    def __rdiv__(self, other):  # pragma: no cover
-        # Only one of __rtruediv__ and __rdiv__ is meaningful at any one time.
         return other / self._wrapped
 
     def __rmod__(self, other):
@@ -408,13 +386,7 @@ class AbstractPyProxyBase:
         self._wrapped *= other
         return self
 
-    def __idiv__(self, other):  # pragma: no cover
-        # Only one of __itruediv__ and __idiv__ is meaningful at any one time.
-        self._wrapped /= other
-        return self
-
     def __itruediv__(self, other):  # pragma: no cover
-        # Only one of __itruediv__ and __idiv__ is meaningful at any one time.
         self._wrapped /= other
         return self
 

--- a/src/zope/proxy/_zope_proxy_proxy.c
+++ b/src/zope/proxy/_zope_proxy_proxy.c
@@ -500,7 +500,7 @@ UNOP(index, call_index)
 
 
 static int
-wrap_nonzero(PyObject *self)
+wrap_bool(PyObject *self)
 {
     return PyObject_IsTrue(Proxy_GET_OBJECT(self));
 }
@@ -513,31 +513,6 @@ static Py_ssize_t
 wrap_length(PyObject *self)
 {
     return PyObject_Length(Proxy_GET_OBJECT(self));
-}
-
-static PyObject *
-wrap_slice(PyObject *self, Py_ssize_t start, Py_ssize_t end)
-{
-    /*
-     * Note that we have arrived here through PySequence_GetSlice
-     * once already, which on Python 2 adjusted indices. We can't call
-     * PySequence_GetSlice again or they will be wrong. So we directly
-     * call the slice method the type provides.
-     */
-    PyObject *obj = Proxy_GET_OBJECT(self);
-	return PySequence_GetSlice(obj, start, end);
-}
-
-static int
-wrap_ass_slice(PyObject *self, Py_ssize_t i, Py_ssize_t j, PyObject *value)
-{
-    PyObject *obj = Proxy_GET_OBJECT(self);
-    if (PyList_Check(obj)) {
-        return PyList_SetSlice(obj, i, j, value);
-    }
-    else {
-        return PySequence_SetSlice(obj, i, j, value);
-    }
 }
 
 static int
@@ -608,7 +583,7 @@ wrap_as_number = {
     wrap_neg,                               /* nb_negative */
     wrap_pos,                               /* nb_positive */
     wrap_abs,                               /* nb_absolute */
-    wrap_nonzero,                           /* nb_nonzero */
+    wrap_bool,                              /* nb_bool, formerly nb_nonzero */
     wrap_invert,                            /* nb_invert */
     wrap_lshift,                            /* nb_lshift */
     wrap_rshift,                            /* nb_rshift */
@@ -647,9 +622,9 @@ wrap_as_sequence = {
     0,                                      /* sq_concat */
     0,                                      /* sq_repeat */
     0,                                      /* sq_item */
-    wrap_slice,                             /* sq_slice */
+    0,                                      /* sq_slice, unused in PY3 */
     0,                                      /* sq_ass_item */
-    wrap_ass_slice,                         /* sq_ass_slice */
+    0,                                      /* sq_ass_slice, unused in PY3 */
     wrap_contains,                          /* sq_contains */
 };
 

--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -191,7 +191,7 @@ class PyProxyBaseTestCase(unittest.TestCase):
         self.assertTrue(o2 > w1)
         self.assertTrue(o2 >= w2)
 
-    def test___nonzero__(self):
+    def test___bool__(self):
         w = self._makeOne(None)
         self.assertFalse(w)
         self.assertTrue(not w)


### PR DESCRIPTION
Fixes #55
See also the equivalent PR in `zope.security` at https://github.com/zopefoundation/zope.security/pull/93