### PR TITLE
Remove Python 2 support code.

### DIFF
--- a/src/zope/proxy/tests/test_proxy.py
+++ b/src/zope/proxy/tests/test_proxy.py
@@ -44,12 +44,6 @@ class PyProxyBaseTestCase(unittest.TestCase):
     getslice = '__getitem__'
     setslice = '__setitem__'
 
-    # Avoid DeprecationWarning for assertRaisesRegexp on Python 3 while
-    # coping with Python 2 not having the Regex spelling variant
-    assertRaisesRegex = getattr(
-        unittest.TestCase, 'assertRaisesRegex',
-        getattr(unittest.TestCase, 'assertRaisesRegexp', None))
-
     def _getTargetClass(self):
         from zope.proxy import PyProxyBase
         return PyProxyBase


### PR DESCRIPTION
Fixes #63

The remaining test failures require https://github.com/zopefoundation/zope.testrunner/issues/157 to be fixed.