### PR TITLE
Respect ``PURE_PYTHON`` environment variable set to ``0``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.1 (unreleased)
 ================
 
+- Respect ``PURE_PYTHON`` environment variable set to ``0``.
+
 
 6.0 (2024-09-17)
 ================

--- a/src/zope/proxy/__init__.py
+++ b/src/zope/proxy/__init__.py
@@ -480,7 +480,7 @@ def py_removeAllProxies(obj):
 
 
 _c_available = False
-if 'PURE_PYTHON' not in os.environ:
+if not int(os.environ.get('PURE_PYTHON', '0')):
     try:  # pragma: no cover
         from zope.proxy._zope_proxy_proxy import ProxyBase as _c_available
     except ImportError:


### PR DESCRIPTION
Setting to 0 should be equivalent to not setting the variable.

Closes https://github.com/zopefoundation/meta/issues/283