### PR TITLE
Adjust minimal required version of zope.security test dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.2 (unreleased)
 ================
 
+- Adjust minimal required version of ``zope.security`` test dependency to ``7.3``.
+
 
 6.1 (2024-10-02)
 ================

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,8 @@ setup(name='zope.proxy',
       zip_safe=False,
       extras_require={
           'test': [
-              'zope.security',  # We have a circular dependency for testing
+              # We have a circular dependency with zope.security for testing
+              'zope.security >= 7.3',
               'zope.testrunner',
           ],
           'docs': [


### PR DESCRIPTION
Fixes #72