### PR TITLE
setuptools is not required at runtime anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,11 @@ setup(name='zope.proxy',
       headers=headers,
       ext_modules=ext_modules,
       python_requires='>=3.9',
+      setup_requires=[
+          'setuptools',
+      ],
       install_requires=[
           'zope.interface',
-          'setuptools',
       ],
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
- [ ] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1084015
