### PR TITLE
Retry pip install steps in GHA to survive truncated PyPI downloads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,15 +127,6 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache epoch
-        id: pip-cache-epoch
-        # ``actions/cache`` never replaces an entry: "if the provided key
-        # matches an existing cache, a new cache is not created". A corrupt
-        # entry would therefore break every run that restores it until GitHub
-        # evicts it. Rotating the key weekly abandons such an entry instead.
-        run: |
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -145,19 +136,30 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
-
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
       - name: Install Build Dependencies (3.15)
         if: startsWith(matrix.python-version, '3.15')
         run: |
-          python -m pip install -U pip
-          pip install -U "setuptools >= 78.1.1,< 82" wheel twine cffi pycparser
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry python -m pip install -U pip
+          retry pip install -U "setuptools >= 78.1.1,< 82" wheel twine cffi pycparser
       - name: Install Build Dependencies
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
-          python -m pip install -U pip
-          pip install -U "setuptools >= 78.1.1,< 82" wheel twine
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry python -m pip install -U pip
+          retry pip install -U "setuptools >= 78.1.1,< 82" wheel twine
 
       - name: Build zope.proxy (macOS x86_64)
         if: >
@@ -205,16 +207,28 @@ jobs:
       - name: Install zope.proxy and dependencies (3.15)
         if: startsWith(matrix.python-version, '3.15')
         run: |
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
           # Install to collect dependencies into the (pip) cache.
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          pip install --pre .[test]
+          retry pip install --pre .[test]
       - name: Install zope.proxy and dependencies
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
           # Install to collect dependencies into the (pip) cache.
-          python -m pip install -U pip "setuptools >= 78.1.1,< 82"
-          pip install .[test]
+          retry python -m pip install -U pip "setuptools >= 78.1.1,< 82"
+          retry pip install .[test]
 
       - name: Check zope.proxy build
         run: |
@@ -300,15 +314,6 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache epoch
-        id: pip-cache-epoch
-        # ``actions/cache`` never replaces an entry: "if the provided key
-        # matches an existing cache, a new cache is not created". A corrupt
-        # entry would therefore break every run that restores it until GitHub
-        # evicts it. Rotating the key weekly abandons such an entry instead.
-        run: |
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -318,8 +323,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
-
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
       - name: Download zope.proxy wheel (Linux/macOS)
         if: "!startsWith(runner.os, 'Windows')"
         uses: actions/download-artifact@v8
@@ -336,10 +340,16 @@ jobs:
       - name: Install zope.proxy ${{ matrix.python-version }}
         if: startsWith(matrix.python-version, '3.15')
         run: |
-          pip install -U wheel "setuptools >= 78.1.1,< 82"
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry pip install -U wheel "setuptools >= 78.1.1,< 82"
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage[toml]
+          retry pip install -U --no-binary :all: coverage[toml]
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
@@ -347,19 +357,25 @@ jobs:
           unzip -n dist/*.whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          pip install --pre -e .[test]
+          retry pip install --pre -e .[test]
       - name: Install zope.proxy
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
-          pip install -U wheel "setuptools >= 78.1.1,< 82"
-          pip install -U coverage[toml]
-          pip install -U 'cffi; platform_python_implementation == "CPython"'
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry pip install -U wheel "setuptools >= 78.1.1,< 82"
+          retry pip install -U coverage[toml]
+          retry pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           ls -l dist/
           unzip -n dist/*.whl -d src
-          pip install -e .[test]
+          retry pip install -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
@@ -414,15 +430,6 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache epoch
-        id: pip-cache-epoch
-        # ``actions/cache`` never replaces an entry: "if the provided key
-        # matches an existing cache, a new cache is not created". A corrupt
-        # entry would therefore break every run that restores it until GitHub
-        # evicts it. Rotating the key weekly abandons such an entry instead.
-        run: |
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -432,8 +439,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
-
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
       - name: Download zope.proxy wheel
         uses: actions/download-artifact@v8
         with:
@@ -441,9 +447,15 @@ jobs:
           path: dist/
       - name: Install zope.proxy
         run: |
-          pip install -U wheel
-          pip install -U coverage[toml]
-          pip install -U  "`ls dist/*.whl`[docs]"
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry pip install -U wheel
+          retry pip install -U coverage[toml]
+          retry pip install -U  "`ls dist/*.whl`[docs]"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
@@ -475,15 +487,6 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache epoch
-        id: pip-cache-epoch
-        # ``actions/cache`` never replaces an entry: "if the provided key
-        # matches an existing cache, a new cache is not created". A corrupt
-        # entry would therefore break every run that restores it until GitHub
-        # evicts it. Rotating the key weekly abandons such an entry instead.
-        run: |
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -493,8 +496,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
-
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
       - name: Download zope.proxy wheel
         uses: actions/download-artifact@v8
         with:
@@ -502,9 +504,15 @@ jobs:
           path: dist/
       - name: Install zope.proxy
         run: |
-          pip install -U wheel
-          pip install -U tox
-          pip install -U  "`ls dist/*.whl`[docs]"
+          # PyPI downloads are occasionally cut off mid-transfer, which makes
+          # pip fail with ``IncompleteRead``. pip does not retry a truncated
+          # download, so retry the complete command. Purge pip's cache before
+          # the last attempt: should a truncated download ever get *cached*,
+          # it would fail every attempt in the same way.
+          retry() { for i in 1 2; do "$@" && return 0; echo "Attempt $i failed, retrying in 15s ..."; sleep 15; done; pip cache purge || true; "$@"; }
+          retry pip install -U wheel
+          retry pip install -U tox
+          retry pip install -U  "`ls dist/*.whl`[docs]"
       - name: Run release check
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
@@ -543,15 +551,6 @@ jobs:
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache epoch
-        id: pip-cache-epoch
-        # ``actions/cache`` never replaces an entry: "if the provided key
-        # matches an existing cache, a new cache is not created". A corrupt
-        # entry would therefore break every run that restores it until GitHub
-        # evicts it. Rotating the key weekly abandons such an entry instead.
-        run: |
-          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -561,8 +560,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}
-
+          key: ${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}
 
       - name: Update pip
         run: python -m pip install -U pip


### PR DESCRIPTION
pip does not retry a download that is cut off mid-transfer (`IncompleteRead`), which kept failing the `pypy-3.11/windows-latest` job (latest: https://github.com/zopefoundation/zope.proxy/actions/runs/32640023699). Wrap the pip install steps in a retry loop (3 attempts, purging pip's cache before the last one) and drop the weekly pip cache key rotation from #82, which did not address the actual cause.

To be ported to zopefoundation/meta later.